### PR TITLE
add a command to trigger plugin

### DIFF
--- a/public/plugin.json
+++ b/public/plugin.json
@@ -18,6 +18,12 @@
                     "label": "Code计算器",
                     "match": "/^[\\.+\\-*/%0-9\\(\\)]*$/",
                     "minLength": 1
+                },
+                {
+                    "type": "regex",
+                    "label": "Code计算器",
+                    "match": "/^=/",
+                    "minLength": 2
                 }
             ]
         }

--- a/src/App.vue
+++ b/src/App.vue
@@ -129,14 +129,11 @@ export default {
   },
   created () {
     utools.onPluginEnter(({ code, type, payload, optional }) => {
-      if (!/^[\.+\-*/%0-9\(\)]*$/.test(payload)) {
-        payload = ''
-      }
-      let result = utools.db.get("code")
-      if (!payload && result) {
-        payload = result.data
-      }
-      this.code = payload
+      if (type !== "regex")
+        payload = "";
+      payload = payload.startsWith("=") ? _.trimStart(payload, "=") : payload;
+
+      this.code = payload || (utools.db.get("code") || {}).data || ""
       this.change()
     })
   }


### PR DESCRIPTION
旧的正则已经不足以匹配后追加的 “<<” 和包含方法的表达式（如：round(0.2+0.3)），所以增加了 "=" 前缀作为新的启动指令。

使用方式：
- ==
    表达式的前置所有等号都将被忽略，所以可以通过这个指令快速启动插件

- =round(0.2+0.3)
    表达式 round(0.2+0.3) 将在插件启动后直接被填充到输入框内